### PR TITLE
use utf8-only text-encoding polyfill

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,11 @@ import { JsSignatureProvider } from 'eosjs/dist/eosjs-jssig';           // devel
 Importing using commonJS syntax is supported by NodeJS out of the box.
 ```js
 const { Api, JsonRpc, RpcError } = require('eosjs');
-const { JsSignatureProvider } = require('eosjs/dist/eosjs-jssig');      // development only
-const fetch = require('node-fetch');                                    // node only; not needed in browsers
-const { TextEncoder, TextDecoder } = require('util');                   // node only; native TextEncoder/Decoder
-const { TextEncoder, TextDecoder } = require('text-encoding');          // React Native, IE11, and Edge Browsers only
+const { JsSignatureProvider } = require('eosjs/dist/eosjs-jssig');          // development only
+const fetch = require('node-fetch');                                        // node only; not needed in browsers
+const { TextEncoder, TextDecoder } = require('util');                       // node only; native TextEncoder/Decoder
+const { TextEncoder, TextDecoder } = require('text-encoding');              // React Native, IE11, and Edge Browsers only
+const { TextEncoder, TextDecoder } = require('@exodus/text-encoding-utf8'); // React Native, IE11, and Edge Browsers only (if Buffer is available)
 ```
 
 ## Basic Usage

--- a/package.json
+++ b/package.json
@@ -28,14 +28,13 @@
     "url": "https://github.com/EOSIO/eosjs.git"
   },
   "dependencies": {
-    "eosjs-ecc": "ExodusMovement/eosjs-ecc#6f9b50127ffddad2da913814a7e1ca3adde87e42",
-    "text-encoding": "0.7.0"
+    "@exodus/text-encoding-utf8": "1.0.1",
+    "eosjs-ecc": "ExodusMovement/eosjs-ecc#6f9b50127ffddad2da913814a7e1ca3adde87e42"
   },
   "devDependencies": {
     "@blockone/tslint-config-blockone": "3.0.0",
     "@types/jest": "24.0.6",
     "@types/node": "11.9.4",
-    "@types/text-encoding": "0.0.35",
     "babel-cli": "6.26.0",
     "babel-preset-env": "1.7.0",
     "babel-preset-stage-1": "6.24.1",

--- a/src/tests/eosjs-api.test.ts
+++ b/src/tests/eosjs-api.test.ts
@@ -1,4 +1,4 @@
-import { TextDecoder, TextEncoder } from 'text-encoding';
+import { TextDecoder, TextEncoder } from '@exodus/text-encoding-utf8';
 import { Api } from '../eosjs-api';
 import { JsonRpc } from '../eosjs-jsonrpc';
 import { JsSignatureProvider } from '../eosjs-jssig';

--- a/yarn.lock
+++ b/yarn.lock
@@ -44,6 +44,11 @@
     debug "^3.1.0"
     lodash.once "^4.1.1"
 
+"@exodus/text-encoding-utf8@1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@exodus/text-encoding-utf8/-/text-encoding-utf8-1.0.1.tgz#f755c19644106b433614804b52c3b1019ee3b3eb"
+  integrity sha512-C4KyZiP30flRAZIEiIvEsFCCl+SOnFeHQK3EorZ0ux2+mPw9dCWlqyyOejroJSso7WR/Qg4WFAs6N0A4VeIkow==
+
 "@types/blob-util@1.3.3":
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/@types/blob-util/-/blob-util-1.3.3.tgz#adba644ae34f88e1dd9a5864c66ad651caaf628a"
@@ -138,11 +143,6 @@
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/@types/sizzle/-/sizzle-2.3.2.tgz#a811b8c18e2babab7d542b3365887ae2e4d9de47"
   integrity sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==
-
-"@types/text-encoding@0.0.35":
-  version "0.0.35"
-  resolved "https://registry.yarnpkg.com/@types/text-encoding/-/text-encoding-0.0.35.tgz#6f14474e0b232bc70c59677aadc65dcc5a99c3a9"
-  integrity sha512-jfo/A88XIiAweUa8np+1mPbm3h2w0s425YrI8t3wk5QxhH6UI7w517MboNVnGDeMSuoFwA8Rwmklno+FicvV4g==
 
 "@webassemblyjs/ast@1.8.3":
   version "1.8.3"
@@ -6223,11 +6223,6 @@ test-exclude@^4.2.1:
     object-assign "^4.1.0"
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
-
-text-encoding@0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/text-encoding/-/text-encoding-0.7.0.tgz#f895e836e45990624086601798ea98e8f36ee643"
-  integrity sha512-oJQ3f1hrOnbRLOcwKz0Liq2IcrvDeZRHXhd9RgLrsT+DjWY/nty1Hi7v3dtkaEYbPYe0mUoOfzRrMwfXXwgPUA==
 
 throat@^4.0.0:
   version "4.1.0"


### PR DESCRIPTION
closes #1

idk if we want @exodus/text-encoding-utf8 as a dep in this repo at all, if it isn't used here directly. @feri42 @unidwell what do u think about me moving it to devDeps and peerDeps instead?